### PR TITLE
Fixes/no autotrust

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pyzt
 googlemaps
 protobuf==3.17.3
 
-git+https://gitlab.com/mobilecoin/pysignald.git@0b37610c1f096300389c3828916ccc420a5b82c7#egg=pysignald
+git+https://gitlab.com/stavros/pysignald.git@5c27c092fd5379f3d2af0ec21be2d915e4e3f256#egg=pysignald
 django-extensions==3.1.3
 aenum==3.1.0
 django-phonenumber-field[phonenumberslite]==2.1.0

--- a/src/signald_client/main.py
+++ b/src/signald_client/main.py
@@ -72,11 +72,11 @@ class Signal(_Signal):
         while self._run:
             try:
                 message = next(messages_iterator)
-            except json.decoder.JSONDecodeError as e:
+            except Exception as e:
                 self.logger.exception("Got an error attempting to get a message from signal!")
                 continue
-            print("Receiving message")
-            print(message)
+
+            self.logger.info(f"Receiving message {message}")
 
             if message.payment:
                 for func in self._payment_handlers:
@@ -115,7 +115,7 @@ class Signal(_Signal):
                     else:
                         self.send_message(recipient=message.source['number'], text=reply)
                 except Exception as e:
-                    print(e)
+                    self.logger.exception(e)
                     raise
 
                 if stop:


### PR DESCRIPTION
Soundtrack of this PR: [Peace Orchestra - Who Am I](https://www.youtube.com/watch?v=aOx109jPH60&t=0s)

### Motivation

We've been using a custom pysignald that handles an exception caused by untrusted users by automatically trusting them. To do this, it gets *all* identities, which is a call pysignald can't handle at the size of our signaldb.

Related ticket: [PySignald `trust_all_untrusted` error: JSONDecodeError when running `get_all_identities()`](https://app.asana.com/0/1200175610893108/1200945887296199)

### In this PR
* Use original pysignald library
* Put a broader try-except around getting the next message from Signal