### PR TITLE
Break out of loop if connection to signal is lost

### DIFF
--- a/src/signald_client/main.py
+++ b/src/signald_client/main.py
@@ -72,6 +72,9 @@ class Signal(_Signal):
         while self._run:
             try:
                 message = next(messages_iterator)
+            except ConnectionResetError as e:
+                self.logger.exception("Got an error attempting to get a message from signal!")
+                raise
             except Exception as e:
                 self.logger.exception("Got an error attempting to get a message from signal!")
                 continue


### PR DESCRIPTION

### Motivation

Losing connection to signal causes a tight exception loop
### In this PR
* Break out for connection reset


