### PR TITLE
Feature/build and submit with tx_proposal from single request, remove mutex locks

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,7 +29,7 @@ services:
         ipv4_address: 10.200.0.6
 
   full-service:
-    image: mobilecoin/full-service:v1.0.1-testnet
+    image: mobilecoin/full-service:v1.1.0-testnet
     volumes:
     - full-service:/data
     tty: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # requirements for signald
 attrs
--e git+https://github.com/mobilecoinofficial/full-service.git@616c7e4218e06610cd4e0f797a74064fa9b10d70#egg=mobilecoin-python-utils&subdirectory=python-utils
--e git+https://github.com/mobilecoinofficial/full-service.git@616c7e4218e06610cd4e0f797a74064fa9b10d70#egg=mobilecoin-cli&subdirectory=cli
+-e git+https://github.com/mobilecoinofficial/full-service.git@d94572e82c48dc615fba046891e3f03cf8028a59#egg=mobilecoin-python-utils&subdirectory=python-utils
+-e git+https://github.com/mobilecoinofficial/full-service.git@d94572e82c48dc615fba046891e3f03cf8028a59#egg=mobilecoin-cli&subdirectory=cli
 
 base58==2.1.0
 django==3.2.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 # requirements for signald
 attrs
--e git+https://github.com/mobilecoinofficial/full-service.git@ef1ab817fbfb1c9a2e44de6a2af774c2e84079e8#egg=mobilecoin&subdirectory=cli
+-e git+https://github.com/mobilecoinofficial/full-service.git@616c7e4218e06610cd4e0f797a74064fa9b10d70#egg=mobilecoin-python-utils&subdirectory=python-utils
+-e git+https://github.com/mobilecoinofficial/full-service.git@616c7e4218e06610cd4e0f797a74064fa9b10d70#egg=mobilecoin-cli&subdirectory=cli
 
 base58==2.1.0
 django==3.2.7

--- a/src/mobot_client/admin.py
+++ b/src/mobot_client/admin.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2021 MobileCoin. All rights reserved.
 from django.contrib import admin
 
-from mobilecoin.utility import pmob2mob
+from mc_util import pmob2mob
 from .models import (
     Store,
     Customer,

--- a/src/mobot_client/management/commands/send_mob_to_customer.py
+++ b/src/mobot_client/management/commands/send_mob_to_customer.py
@@ -32,8 +32,6 @@ class Command(BaseCommand):
         mcc = MCClient()
         self.payments = Payments(
             mcc,
-            mcc.minimum_fee_pmob,
-            mcc.account_id,
             store,
             self.messenger,
             signal,

--- a/src/mobot_client/mobot.py
+++ b/src/mobot_client/mobot.py
@@ -139,9 +139,8 @@ class MOBot:
                 receipt_status = self.mcc.check_receiver_receipt_status(
                     self.mcc.public_address, receipt
                 )
-                txo_id = receipt_status["txo"]["txo_id"]
                 transaction_status = receipt_status["receipt_transaction_status"]
-                self.logger.info(f"Waiting for {receipt} with txo {txo_id}, current status {receipt_status}")
+                self.logger.info(f"Waiting for {receipt}, current status {receipt_status}")
 
             if transaction_status != "TransactionSuccess":
                 self.logger.error(f"failed {transaction_status}")

--- a/src/mobot_client/payments/client.py
+++ b/src/mobot_client/payments/client.py
@@ -1,12 +1,13 @@
 # Copyright (c) 2021 MobileCoin. All rights reserved.
+import time
 
-from mobilecoin.utility import b58_wrapper_to_b64_public_address
-from mobilecoin import Client as MCC
+from mc_util import b58_wrapper_to_b64_public_address
+from mobilecoin import Client
 
 from django.conf import settings
 
 
-class MCClient(MCC):
+class MCClient(Client):
     def __init__(self):
         super().__init__(settings.FULLSERVICE_URL)
         self.public_address, self.account_id = self._get_default_account_info()

--- a/src/mobot_client/payments/payments.py
+++ b/src/mobot_client/payments/payments.py
@@ -7,6 +7,7 @@ import logging
 
 
 import mobilecoin as mc
+import mc_util
 from signald_client import Signal
 
 from mobot_client.logger import SignalMessenger
@@ -41,7 +42,6 @@ class Payments:
         self.signal = signal
         self.messenger = messenger
         self.logger = logging.getLogger("MOBot.Payments")
-        self._transaction_lock = threading.Lock()
         self.timers = TimerFactory("Payments", self.logger)
         with self.timers.get_timer("Startup"):
             self.logger.info("Payments started")
@@ -92,18 +92,14 @@ class Payments:
 
     def send_mob_to_address(self, source, account_id: str, amount_in_mob: Decimal, customer_payments_address: str, memo="Refund"):
         # customer_payments_address is b64 encoded, but full service wants a b58 address
-        customer_payments_address = mc.utility.b64_public_address_to_b58_wrapper(
+        customer_payments_address = mc_util.b64_public_address_to_b58_wrapper(
             customer_payments_address
         )
 
-        with self.timers.get_timer("acquire_lock"):
-            self._transaction_lock.acquire(blocking=True)
-            with self.timers.get_timer("build_and_send_transaction"):
-                tx_proposal = self.mcc.build_transaction(
-                    account_id, amount_in_mob, customer_payments_address
-                )
-                txo_id = self.submit_transaction(tx_proposal, account_id)
-        self._transaction_lock.release()
+        with self.timers.get_timer("build_and_send_transaction"):
+            txo_id, tx_proposal = self.mcc.build_and_submit_transaction_with_proposal(
+                account_id, amount_in_mob, customer_payments_address
+            )
 
         for _ in range(10):
             try:
@@ -122,20 +118,9 @@ class Payments:
             )
             raise PaymentException("Could not send payment")
 
-    def submit_transaction(self, tx_proposal: dict, account_id: str):
-        # retry up to 10 times in case there's some failure with a 1 sec timeout in between each
-        with self.timers.get_timer("submit_transaction"):
-            transaction_log = self.mcc.submit_transaction(tx_proposal, account_id)
-            list_of_txos = transaction_log["output_txos"]
-
-            if len(list_of_txos) > 1:
-                raise ValueError("Found more than one txout for this chat bot-initiated transaction.")
-
-            return list_of_txos[0]["txo_id_hex"]
-
     def send_payment_receipt(self, source: str, tx_proposal: dict, memo="Refund"):
         receiver_receipt = self.create_receiver_receipt(tx_proposal)
-        receiver_receipt = mc.utility.full_service_receipt_to_b64_receipt(
+        receiver_receipt = mc_util.full_service_receipt_to_b64_receipt(
             receiver_receipt
         )
         resp = self.signal.send_payment_receipt(source, receiver_receipt, memo)

--- a/src/mobot_client/payments/payments.py
+++ b/src/mobot_client/payments/payments.py
@@ -2,7 +2,6 @@
 
 import time
 from decimal import Decimal
-import threading
 import logging
 
 


### PR DESCRIPTION
Soundtrack of this PR: [Build and submit]()

### Motivation

Allows us to remove mutex locks and build and submit in a single request for speed and reliability.

### In this PR

Addresses:
 * [MOBot: build_and_submit all at once to avoid uTXO clashes](https://app.asana.com/0/1200965155268853/1200866955909822)
 * [MOBot: Migrate docker image to new full-service](https://app.asana.com/0/1200965155268853/1201022031417958)
 * [MOBot: Migrate to new python client for full-service API](https://app.asana.com/0/1200965155268853/1201002142005233)

### Future Work
* Related Full-service ticket still in review, so this points to a specific commit.
