### PR TITLE
add fog-ingest-enclave-css to full-service config

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,8 +38,7 @@ services:
     - --peer=mc://node2.test.mobilecoin.com/
     - --tx-source-url=https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.test.mobilecoin.com/
     - --tx-source-url=https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node2.test.mobilecoin.com/
-    - --fog-ingest-enclave-css
-    - /usr/local/bin/ingest-enclave.css
+    - --fog-ingest-enclave-css=/usr/local/bin/ingest-enclave.css
     expose:
     - 9090
     ports:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,6 +38,8 @@ services:
     - --peer=mc://node2.test.mobilecoin.com/
     - --tx-source-url=https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node1.test.mobilecoin.com/
     - --tx-source-url=https://s3-us-west-1.amazonaws.com/mobilecoin.chain/node2.test.mobilecoin.com/
+    - --fog-ingest-enclave-css
+    - /usr/local/bin/ingest-enclave.css
     expose:
     - 9090
     ports:


### PR DESCRIPTION
Soundtrack of this PR: London Fog

### Motivation

MOBot communicates with Signal clients and so it should be expected to be sending funds to fog-enabled addresses. Thus the companion full-service needs to be configured with a fog-ingest-enclave-css.

### In this PR
* added fog-ingest-enclave-css flag pointing to already present ingest-enclave.css to the docker-compose.yaml block for full-service.
