### PR TITLE
add backups/restore sidecars to chart

### DIFF
--- a/chart/templates/_helpers.tpl
+++ b/chart/templates/_helpers.tpl
@@ -115,3 +115,14 @@ fullService ConfigMap Name
     {{- include "chart.fullname" . }}-{{ .Values.fullServiceConfig.configMap.name }}
   {{- end }}
 {{- end }}
+
+{{/*
+backupSidecar Secret Name
+*/}}
+{{- define "chart.backupsSidecarSecretName" -}}
+  {{- if .Values.backupsSidecar.secret.external }}
+    {{- .Values.backupsSidecar.secret.name }}
+  {{- else }}
+    {{- include "chart.fullname" . }}-{{ .Values.backupsSidecar.secret.name }}
+  {{- end }}
+{{- end }}

--- a/chart/templates/backups-sidecar-secret.yaml
+++ b/chart/templates/backups-sidecar-secret.yaml
@@ -1,0 +1,13 @@
+{{ if eq .Values.backupsSidecar.secret.external false }}
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: {{ include "chart.backupsSidecarSecretName" . }}
+  labels:
+    {{- include "chart.labels" . | nindent 4 }}
+data:
+  ENCRYPT_KEY: {{ .Values.backupsSidecar.secret.data.ENCRYPT_KEY | b64enc }}
+  AZURE_STORAGE_ACCOUNT: {{ .Values.backupsSidecar.secret.data.AZURE_STORAGE_ACCOUNT | b64enc }}
+  AZURE_STORAGE_KEY: {{ .Values.backupsSidecar.secret.data.AZURE_STORAGE_KEY | b64enc }}
+{{- end }}

--- a/chart/templates/full-service-statefulset.yaml
+++ b/chart/templates/full-service-statefulset.yaml
@@ -27,6 +27,7 @@ spec:
         runAsGroup: 1000
         fsGroup: 2000
         fsGroupChangePolicy: "OnRootMismatch"
+      {{- if .Values.backupsSidecar.enabled }}
       shareProcessNamespace: true
       initContainers:
       - name: restore-sidecar
@@ -64,6 +65,7 @@ spec:
           mountPath: /data
         - name: tmp
           mountPath: /tmp
+      {{- end }}
       containers:
       - name: full-service
         securityContext:
@@ -109,6 +111,7 @@ spec:
           mountPath: /data
         resources:
           {{- toYaml .Values.fullService.resources | nindent 12 }}
+      {{- if .Values.backupsSidecar.enabled }}
       - name: backups-sidecar
         securityContext:
           capabilities:
@@ -145,6 +148,7 @@ spec:
           readOnly: true
         - name: tmp
           mountPath: /tmp
+      {{- end }}
       nodeSelector:
         {{- toYaml .Values.fullService.nodeSelector | nindent 8 }}
       affinity:

--- a/chart/templates/full-service-statefulset.yaml
+++ b/chart/templates/full-service-statefulset.yaml
@@ -27,6 +27,43 @@ spec:
         runAsGroup: 1000
         fsGroup: 2000
         fsGroupChangePolicy: "OnRootMismatch"
+      shareProcessNamespace: true
+      initContainers:
+      - name: restore-sidecar
+        securityContext:
+          capabilities:
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+        image: "{{ .Values.backupsSidecar.image.repository }}:{{ .Values.backupsSidecar.image.tag }}"
+        imagePullPolicy: Always
+        args:
+        - /app/bin/full-service/restore.sh
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: ENCRYPT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "chart.backupsSidecarSecretName" . }}
+              key: ENCRYPT_KEY
+        - name: AZURE_STORAGE_ACCOUNT
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "chart.backupsSidecarSecretName" . }}
+              key: AZURE_STORAGE_ACCOUNT
+        - name: AZURE_STORAGE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "chart.backupsSidecarSecretName" . }}
+              key: AZURE_STORAGE_KEY
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        - name: tmp
+          mountPath: /tmp
       containers:
       - name: full-service
         securityContext:
@@ -58,6 +95,7 @@ spec:
               name: {{ include "chart.fullServiceConfigMapName" . }}
               key: tx_source_url_1
         args:
+        - "--fog-ingest-enclave-css=/usr/local/bin/ingest-enclave.css"
         - "--peer=$(PEER_0)"
         - "--peer=$(PEER_1)"
         - "--tx-source-url=$(TX_SOURCE_URL_0)"
@@ -71,14 +109,52 @@ spec:
           mountPath: /data
         resources:
           {{- toYaml .Values.fullService.resources | nindent 12 }}
+      - name: backups-sidecar
+        securityContext:
+          capabilities:
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+        image: "{{ .Values.backupsSidecar.image.repository }}:{{ .Values.backupsSidecar.image.tag }}"
+        imagePullPolicy: Always
+        args:
+        - "while true; do sleep 60; /app/bin/full-service/backup.sh; sleep 3600; done"
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: ENCRYPT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "chart.backupsSidecarSecretName" . }}
+              key: ENCRYPT_KEY
+        - name: AZURE_STORAGE_ACCOUNT
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "chart.backupsSidecarSecretName" . }}
+              key: AZURE_STORAGE_ACCOUNT
+        - name: AZURE_STORAGE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "chart.backupsSidecarSecretName" . }}
+              key: AZURE_STORAGE_KEY
+        volumeMounts:
+        - name: data
+          mountPath: /data
+          readOnly: true
+        - name: tmp
+          mountPath: /tmp
       nodeSelector:
         {{- toYaml .Values.fullService.nodeSelector | nindent 8 }}
       affinity:
         {{- toYaml .Values.fullService.affinity | nindent 8 }}
       tolerations:
         {{- toYaml .Values.fullService.tolerations | nindent 8 }}
-      {{- if eq .Values.fullService.persistence.enabled false }}
       volumes:
+      - name: tmp
+        emptyDir: {}
+      {{- if eq .Values.fullService.persistence.enabled false }}
       - name: data
         emptyDir: {}
       {{- end }}

--- a/chart/templates/signald-deployment.yaml
+++ b/chart/templates/signald-deployment.yaml
@@ -23,6 +23,43 @@ spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
+      shareProcessNamespace: true
+      initContainers:
+      - name: restore-sidecar
+        securityContext:
+          capabilities:
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+        image: "{{ .Values.backupsSidecar.image.repository }}:{{ .Values.backupsSidecar.image.tag }}"
+        imagePullPolicy: Always
+        args:
+        - /app/bin/signald/restore.sh
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: ENCRYPT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "chart.backupsSidecarSecretName" . }}
+              key: ENCRYPT_KEY
+        - name: AZURE_STORAGE_ACCOUNT
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "chart.backupsSidecarSecretName" . }}
+              key: AZURE_STORAGE_ACCOUNT
+        - name: AZURE_STORAGE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "chart.backupsSidecarSecretName" . }}
+              key: AZURE_STORAGE_KEY
+        volumeMounts:
+        - name: mobot
+          mountPath: /signald
+        - name: tmp
+          mountPath: /tmp
       containers:
       - name: signald
         securityContext:
@@ -43,6 +80,42 @@ spec:
           name: tmp
         resources:
           {{- toYaml .Values.signald.resources | nindent 12 }}
+      - name: backups-sidecar
+        securityContext:
+          capabilities:
+            drop:
+            - all
+          readOnlyRootFilesystem: true
+        image: "{{ .Values.backupsSidecar.image.repository }}:{{ .Values.backupsSidecar.image.tag }}"
+        imagePullPolicy: Always
+        args:
+        - "while true; do sleep 60; /app/bin/signald/backup.sh; sleep 3600; done"
+        env:
+        - name: NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: ENCRYPT_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "chart.backupsSidecarSecretName" . }}
+              key: ENCRYPT_KEY
+        - name: AZURE_STORAGE_ACCOUNT
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "chart.backupsSidecarSecretName" . }}
+              key: AZURE_STORAGE_ACCOUNT
+        - name: AZURE_STORAGE_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ include "chart.backupsSidecarSecretName" . }}
+              key: AZURE_STORAGE_KEY
+        volumeMounts:
+        - name: mobot
+          mountPath: /signald
+          readOnly: true
+        - name: tmp
+          mountPath: /tmp
       nodeSelector:
         {{- toYaml .Values.signald.nodeSelector | nindent 8 }}
       affinity:

--- a/chart/templates/signald-deployment.yaml
+++ b/chart/templates/signald-deployment.yaml
@@ -23,6 +23,7 @@ spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
+      {{- if .Values.backupsSidecar.enabled }}
       shareProcessNamespace: true
       initContainers:
       - name: restore-sidecar
@@ -60,6 +61,7 @@ spec:
           mountPath: /signald
         - name: tmp
           mountPath: /tmp
+      {{- end }}
       containers:
       - name: signald
         securityContext:
@@ -80,6 +82,7 @@ spec:
           name: tmp
         resources:
           {{- toYaml .Values.signald.resources | nindent 12 }}
+      {{- if .Values.backupsSidecar.enabled }}
       - name: backups-sidecar
         securityContext:
           capabilities:
@@ -116,6 +119,7 @@ spec:
           readOnly: true
         - name: tmp
           mountPath: /tmp
+      {{- end }}
       nodeSelector:
         {{- toYaml .Values.signald.nodeSelector | nindent 8 }}
       affinity:

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -112,7 +112,9 @@ mobotDatabase:
   sslMode: "disable"
   sslRootCert: ""
 
+## Backup/Restore flat files to azure blob storage
 backupsSidecar:
+  enabled: false
   image:
     repository: mobilecoin/infra-replication-sidecar
     tag: v0.0.1

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -111,3 +111,17 @@ mobotDatabase:
   port: "5432"
   sslMode: "disable"
   sslRootCert: ""
+
+backupsSidecar:
+  image:
+    repository: mobilecoin/infra-replication-sidecar
+    tag: v0.0.1
+  # Create backups-sidecar secret or set external 'false'
+  secret:
+    external: true
+    name: backups-sidecar
+
+    data:
+      ENCRYPT_KEY: <file encryption passphrase>
+      AZURE_STORAGE_ACCOUNT: <azure storage account name>
+      AZURE_STORAGE_KEY: <azure storage account access key>


### PR DESCRIPTION
### Motivation

Add backup and restore sidecars to full-service and signald apps.

### In this PR

- values for backup sidecar.
- secret template.
- update singlad deployment.
- update full-service statefulset.

