### PR TITLE
Set default values for database 

### DIFF
--- a/src/mobot/settings.py
+++ b/src/mobot/settings.py
@@ -116,9 +116,9 @@ WSGI_APPLICATION = 'mobot.wsgi.application'
 if DATABASE == "postgresql":
     try:
         DATABASE_NAME = os.environ.get("DATABASE_NAME", "mobot")
-        DATABASE_USER = os.environ["DATABASE_USER"]
-        DATABASE_PASSWORD = os.environ["DATABASE_PASSWORD"]
-        DATABASE_HOST = os.environ["DATABASE_HOST"]
+        DATABASE_USER = os.environ.get("DATABASE_USER", "postgres")
+        DATABASE_PASSWORD = os.environ.get("DATABASE_PASSWORD", "password")
+        DATABASE_HOST = os.environ.get("DATABASE_HOST", "127.0.0.1")
     except KeyError:
         print("expecting environment variables for database fields")
 


### PR DESCRIPTION
### Motivation

Fix GHA build failures.

`manage.py` tasks that don't require the database now require the env vars for the database to be set? Set "normal" defaults for these env vars so the docker build will run. 

### In this PR
* set usual, dumb defaults for "DATABASE_USER", "DATABASE_PASSWORD" and "DATABASE_HOST"

